### PR TITLE
Enhance DeckDetails component with card images and grid layout

### DIFF
--- a/client/src/components/DeckDetails/DeckDetails.css
+++ b/client/src/components/DeckDetails/DeckDetails.css
@@ -24,3 +24,17 @@
   border-radius: 5px;
   background-color: #f9f9f9;
 }
+
+.card-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.card-image {
+  width: 100px;
+  height: auto;
+  margin-right: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}

--- a/client/src/components/DeckDetails/DeckDetails.css
+++ b/client/src/components/DeckDetails/DeckDetails.css
@@ -5,36 +5,33 @@
 .deck-details h2 {
   font-size: 24px;
   margin-bottom: 10px;
+  text-align: center;
 }
 
 .deck-details p {
   font-size: 18px;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
+  text-align: center;
 }
 
-.deck-details ul {
-  list-style-type: none;
-  padding: 0;
-}
-
-.deck-details li {
-  margin-bottom: 10px;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  background-color: #f9f9f9;
-}
-
-.card-item {
-  display: flex;
-  align-items: center;
-  margin-bottom: 10px;
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); /* Responsive grid */
+  gap: 20px;
+  justify-items: center;
 }
 
 .card-image {
-  width: 100px;
+  width: 150px; /* Default size */
   height: auto;
-  margin-right: 10px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover effect */
+  cursor: pointer;
   border: 1px solid #ccc;
   border-radius: 5px;
+}
+
+.card-image:hover {
+  transform: scale(1.2); /* Expand the card on hover */
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); /* Add a shadow effect */
+  z-index: 10; /* Ensure the hovered card appears on top */
 }

--- a/client/src/components/DeckDetails/DeckDetails.css
+++ b/client/src/components/DeckDetails/DeckDetails.css
@@ -22,7 +22,7 @@
 }
 
 .card-image {
-  width: 150px; /* Default size */
+  width: 250px; /* Increased default size */
   height: auto;
   transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover effect */
   cursor: pointer;

--- a/client/src/components/DeckDetails/DeckDetails.jsx
+++ b/client/src/components/DeckDetails/DeckDetails.jsx
@@ -58,23 +58,16 @@ const DeckDetails = () => {
     <div className="deck-details">
       <h2>{deck.deckName}</h2>
       <p>Total Cards: {totalCards}</p> {/* Display the total number of cards */}
-      <h3>Cards in this Deck:</h3>
-      {deck.cards.length > 0 ? (
-        <ul>
-          {deck.cards.map((card, index) => (
-            <li key={index} className="card-item">
-              {card.imageUrl ? (
-                <img src={card.imageUrl} alt={card.name} className="card-image" />
-              ) : (
-                <p>Image not available</p>
-              )}
-              <strong>{card.name}</strong> - {card.manaCost} ({card.type})
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No cards in this deck yet.</p>
-      )}
+      <div className="card-grid">
+        {deck.cards.map((card, index) => (
+          <img
+            key={index}
+            src={card.imageUrl}
+            alt={card.name}
+            className="card-image"
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Fetch and display card images in the DeckDetails component, replace the card list with a responsive grid layout, and increase the default size of card images for better visibility.

Close #48
Close #24