### PR TITLE
Add Docker support for client and server setup

### DIFF
--- a/client/dockerfile
+++ b/client/dockerfile
@@ -1,0 +1,12 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+services:
+  mongo:
+    image: mongo:7
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+  server:
+    build: ./server
+    ports:
+      - "5001:5001"
+    environment:
+      - MONGO_URI=mongodb://mongo:27017/commander_decks
+    depends_on:
+      - mongo
+
+  client:
+    build: ./client
+    ports:
+      - "5173:5173"
+    environment:
+      - VITE_API_URL=http://localhost:5001
+    depends_on:
+      - server
+
+volumes:
+  mongo-data:

--- a/server/dockerfile
+++ b/server/dockerfile
@@ -1,0 +1,12 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5001
+
+CMD ["node", "server.js"]

--- a/server/server.js
+++ b/server/server.js
@@ -27,7 +27,7 @@ app.use((req, res, next) => {
 });
 
 // Connect to MongoDB
-const CONNECTION_URL = process.env.MONGO_URI; // Get the connection string from .env
+const CONNECTION_URL = process.env.MONGO_URI || "mongodb://localhost:27017/commander_decks"; // Use Docker or local
 mongoose
   .connect(CONNECTION_URL)
   .then(() => console.log("Connected to MongoDB Atlas"))


### PR DESCRIPTION
Introduce a Dockerfile for both client and server, along with an initial docker-compose configuration to manage services. Update the MongoDB connection URL to fallback to a local instance if the MONGO_URI environment variable is not set.

Close #61